### PR TITLE
Only install Tuist if is not already installed

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
     - BITRISE_STEP_ID: tuist
-    - BITRISE_STEP_VERSION: "0.0.1"
+    - BITRISE_STEP_VERSION: "0.0.2"
     - BITRISE_STEP_GIT_CLONE_URL: https://github.com/tuist/bitrise-step-tuist.git
     - MY_STEPLIB_REPO_FORK_GIT_URL: $MY_STEPLIB_REPO_FORK_GIT_URL
 

--- a/step.sh
+++ b/step.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 
-curl -Ls https://install.tuist.io | bash
+if ! [ -x "$(command -v tuist)" ]; then
+    curl -Ls https://install.tuist.io | bash
+fi
 
 tuist $command


### PR DESCRIPTION
When running a bitrise workflow locally tuist always attempts to install itself, which requires root access and asks for the user's password, which besides being annoying, causes users that thought had left a workflow running to return and find it never started.
For the time being we are disabling the tuist step out of CI, but this runs the risk of producing different results, i.e. if the user had made changes to the already generated Xcode project.
To fix this I'm proposing only installing tuist if is not already installed.