### PR TITLE
Added dependency to curl instead of wget

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -33,11 +33,9 @@ run_if: ""
 
 deps:
   brew:
-    - name: git
-    - name: wget
+    - name: curl
   apt_get:
-    - name: git
-    - name: wget
+    - name: curl
 
 toolkit:
   bash:


### PR DESCRIPTION
The step script uses only `curl` and not `wget`

Related to https://github.com/bitrise-io/bitrise-steplib/pull/3701